### PR TITLE
docs: move local dev details from CLAUDE.md to DEV.md

### DIFF
--- a/.claude/ship-initialized
+++ b/.claude/ship-initialized
@@ -1,0 +1,3 @@
+initialized=2026-02-18T11:46:54+07:00
+reviewer=claude-reviewer-max
+ci=none

--- a/DEV.md
+++ b/DEV.md
@@ -105,3 +105,39 @@ To bridge a Discord channel and Telegram group together:
    ```
 5. Ensure your Matrix user has admin power level in the room (use Synapse admin API if needed)
 
+## Lima VM Details
+
+- Name: `matrix`
+- SSH: `limactl shell matrix` or `ssh -p <port> nick@127.0.0.1`
+- SSH key: `/Users/nick/.lima/_config/user`
+- Port changes on restart -- check with `limactl list` and update `inventory/hosts`
+
+## Local Credentials
+
+Stored in `.env.local` (gitignored). Used for local dev only.
+
+## Local Ansible Vars
+
+`matrix-docker-ansible-deploy/inventory/host_vars/matrix.local/vars.yml`
+
+Critical settings that were painful to debug:
+- `matrix_homeserver_url`: MUST include `:8443` port
+- `matrix_synapse_public_baseurl`: MUST include `:8443` port (fixes Element "syncing" freeze)
+- `matrix_client_element_default_hs_url`: MUST include `:8443` port
+- `traefik_*` variables (NOT `devture_traefik_*` -- naming changed in playbook migration)
+- `traefik_ssl_test: true` for self-signed certs
+
+## Local Synapse Admin API
+
+```bash
+curl -sk -X POST 'https://matrix.local:8443/_synapse/admin/v1/rooms/<room_id>/make_room_admin' \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id": "@nick:local"}'
+```
+
+## Local Troubleshooting
+
+1. **Element can't connect**: Browser needs to accept self-signed cert at `https://matrix.local:8443/_matrix/client/versions` first
+2. **Element stuck syncing**: Missing `:8443` port in `matrix_synapse_public_baseurl`
+3. **DM popup disappears in Element**: Chrome bug -- use Safari, or clear site data

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1193,7 +1193,9 @@ Ranked by feasibility and practical value:
 
 ### Setup
 
-- **Matrix homeserver**: Synapse via matrix-docker-ansible-deploy, running in Lima VM on macOS
+> **Note:** These tests were performed on a local development environment (Lima VM on macOS). The production superbridge now runs on a GCE VPS at `35-201-14-61.sslip.io`.
+
+- **Matrix homeserver**: Synapse via matrix-docker-ansible-deploy (local dev: Lima VM on macOS; production: GCE VPS)
 - **Discord bridge**: mautrix-discord v0.7.2 with double puppeting
 - **Telegram bridge**: mautrix-telegram v0.15.3 with double puppeting
 - **Test room**: Discord `#general` (enspyrco server) bridged to Telegram "Superbridge test" group


### PR DESCRIPTION
## Summary
- Move local Lima VM setup, credentials, Ansible vars, and troubleshooting from CLAUDE.md to DEV.md
- Focus CLAUDE.md on production environment (GCE VPS) and operational reference
- Add context note in RESEARCH.md clarifying tests were performed on local dev environment

## Test plan
- [x] Verify CLAUDE.md accurately reflects production environment
- [x] Verify DEV.md contains all moved local dev content
- [x] No secrets exposed in changes

Generated with [Claude Code](https://claude.com/claude-code)